### PR TITLE
Add files via upload

### DIFF
--- a/AutoTowersGenerator.py
+++ b/AutoTowersGenerator.py
@@ -580,7 +580,7 @@ class AutoTowersGenerator(QObject, Extension):
             return
 
         # Proceed if the g-code has not already been post-processed
-        if self._gcodeProcessedMarker not in gcode[0]:
+        if (self._towerControllerPostProcessingCallback != None) and (self._gcodeProcessedMarker not in gcode[0]):
 
             # Mark the g-code as having been post-processed
             gcode[0] = gcode[0] + self._gcodeProcessedMarker + '\n'

--- a/Postprocessing/RetractTower_PostProcessing.py
+++ b/Postprocessing/RetractTower_PostProcessing.py
@@ -63,7 +63,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
     currentValue = -1
     save_e = -1
 
-    if towerType == 'speed':
+    if towerType == 'Speed':
         lcd_gcode = f'M117 SPD {startValue:.1f}mm/s'
     else:
         lcd_gcode = f'M117 DST {startValue: .1f}mm'
@@ -102,7 +102,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                         if relative_extrusion:
                             # Retracting filament (relative)
                             if current_e<0:
-                                if towerType == 'speed':
+                                if towerType == 'Speed':
                                     lines[lineIndex] = f'G1 F{int(currentValue * 60)} E{current_e:.5f} ; AutoTowersGenerator retracting filament at {currentValue} mm/s (relative)' # Speed value must be multiplied by 60 for the gcode
                                     lcd_gcode = f'M117 SPD {int(currentValue)}mm/s ; AutoTowersGenerator added'
                                 else:
@@ -110,7 +110,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                                     lcd_gcode = f'M117 DST {currentValue:.1f}mm ; AutoTowersGenerator added'
                             # Extruding filament (relative)
                             else:
-                                if towerType == 'speed':
+                                if towerType == 'Speed':
                                     lines[lineIndex] = f'G1 F{int(currentValue * 60)} E{current_e:.5f} ; AutoTowersGenerator extruding filament at {currentValue} mm/s (relative)' # Speed value must be multiplied by 60 for the gcode
                                     lcd_gcode = f'M117 SPD {int(currentValue)}mm/s ; AutoTowersGenerator added'
                                 else:
@@ -123,7 +123,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                         else:
                             # Retracting filament (absolute)
                             if save_e > current_e:
-                                if towerType == 'speed':
+                                if towerType == 'Speed':
                                     lines[lineIndex] = f'G1 F{int(currentValue * 60)} E{current_e:.5f} ; AutoTowersGenerator retracting filament at {currentValue} mm/s (absolute)' # Speed value must be multiplied by 60 for the gcode
                                     lcd_gcode = f'M117 SPD {int(currentValue)}mm/s ; AutoTowersGenerator added'
                                 else:
@@ -132,7 +132,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                                     lcd_gcode = f'M117 DST {currentValue:.1f}mm ; AutoTowersGenerator added'
                             # Resetting the retraction
                             else:
-                                if towerType == 'speed':
+                                if towerType == 'Speed':
                                     lines[lineIndex] = f'G1 F{int(currentValue * 60)} E{current_e:.5f} ; AutoTowersGenerator setting retraction speed to {currentValue} mm/s' # Speed value must be multiplied by 60 for the gcode
                                     lcd_gcode = f'M117 SPD {int(currentValue)}mm/s ; AutoTowersGenerator added'
 
@@ -148,7 +148,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                     first_code = True
                     lines.insert(lineIndex + 1, '; AutoTowersGenerator start of the first section')
                     Logger.log('d', f'Start of first section at layer {layerIndex  - 2} - Setting the retraction {towerType} to {currentValue}')
-                    if towerType == 'speed':
+                    if towerType == 'Speed':
                         lcd_gcode = f'M117 SPD {startValue:.1f}mm/s ; AutoTowersGenerator added'
                     else:
                         lcd_gcode = f'M117 DST {startValue:.1f}mm ; AutoTowersGenerator added'
@@ -158,7 +158,7 @@ def execute(gcode, startValue, valueChange, sectionLayers, baseLayers, towerType
                     currentValue += valueChange
                     lines.insert(lineIndex + 1, '; AutoTowersGenerator start of the next section')
                     Logger.log('d', f'New section at layer {layerIndex - 2} - Setting the retraction {towerType} to {currentValue}')
-                    if towerType == 'speed':
+                    if towerType == 'Speed':
                         lcd_gcode = f'M117 SPD {startValue:.1f}mm/s ; AutoTowersGenerator added'
                     else:
                         lcd_gcode = f'M117 DST {startValue:.1f}mm ; AutoTowersGenerator added'

--- a/Resources/QML/QT6/RetractTowerDialog.qml
+++ b/Resources/QML/QT6/RetractTowerDialog.qml
@@ -71,6 +71,18 @@ UM.Dialog
 
             UM.Label 
             { 
+                text: "Scale" 
+            }
+            Cura.TextField
+            {
+                Layout.preferredWidth: numberInputWidth
+                validator: RegularExpressionValidator { regularExpression: /[0-9]*(\.[0-9]+)?/ }
+                text: manager.scaleStr
+                onTextChanged: if (manager.scaleStr != text) manager.scaleStr = text
+            }
+
+            UM.Label 
+            { 
                 text: "Starting Value" 
             }
             Cura.TextField

--- a/Resources/QML/QT6/TempTowerDialog.qml
+++ b/Resources/QML/QT6/TempTowerDialog.qml
@@ -51,6 +51,20 @@ UM.Dialog
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignTop
 
+
+            UM.Label 
+            { 
+                text: "Scale" 
+            }
+            Cura.TextField
+            {
+                Layout.preferredWidth: numberInputWidth
+                validator: RegularExpressionValidator { regularExpression: /[0-9]*(\.[0-9]+)?/ }
+                text: manager.scaleStr
+                onTextChanged: if (manager.scaleStr != text) manager.scaleStr = text
+            }
+
+
             UM.Label
             {
                 text: "Starting Temperature"

--- a/Resources/settings.json
+++ b/Resources/settings.json
@@ -1,0 +1,1 @@
+{"openscad path": "C:\\Program Files (x86)\\OpenSCAD\\openscad.exe"}


### PR DESCRIPTION
-Added options to scale the models in the retract and temp tower custom model options (did not add to others, but changes would be similar)
-Made text on towers not appear if scaled below 50% (some work could be done to make the text smaller, this was just quicker for me)
-Fixed a bug that would make a retraction distance tower when retraction speed was selected
-Fixed a bug that would try to run self._towerControllerPostProcessingCallback while is none, resulting in an error during post processing

Love this plugin, would love to see the scale option added to the official version